### PR TITLE
style(countup.css): reduced margins

### DIFF
--- a/contrib/css/countup.css
+++ b/contrib/css/countup.css
@@ -3,8 +3,8 @@
   font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
   color: black;
   background-color: white;
-  margin: 1rem;
-  padding: 1rem;
+  margin: 0;
+  padding: 0;
   border: 2px solid #444;
   h1 {
     text-align: center;

--- a/dist/css/countup.scss
+++ b/dist/css/countup.scss
@@ -3,8 +3,8 @@
   font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
   color: black;
   background-color: white;
-  margin: 1rem;
-  padding: 1rem;
+  margin: 0;
+  padding: 0;
   border: 2px solid #444;
   h1 {
     text-align: center;

--- a/exampleSite/go.mod
+++ b/exampleSite/go.mod
@@ -3,6 +3,6 @@ module github.com/anoduck/mod-countup/exampleSite
 go 1.19
 
 require (
-	github.com/anoduck/mod-countup v0.0.5 // indirect
+	github.com/anoduck/mod-countup v0.1.0 // indirect
 	github.com/gethinode/mod-utils/v2 v2.9.0 // indirect
 )

--- a/exampleSite/go.sum
+++ b/exampleSite/go.sum
@@ -4,6 +4,8 @@ github.com/anoduck/mod-countup v0.0.2 h1:8nAT3QxNVcexz4Rd7gwCuSETlc2ytFT3au4e4y/
 github.com/anoduck/mod-countup v0.0.2/go.mod h1:j4DhQAAE6qmED5KD3o43cCHYD0Q7AVMMUUZDSkS2a8Y=
 github.com/anoduck/mod-countup v0.0.5 h1:63ATHVBTHTPfB9mHOzN0ZiMWheC0tkshrQ0+BTnvV9E=
 github.com/anoduck/mod-countup v0.0.5/go.mod h1:j4DhQAAE6qmED5KD3o43cCHYD0Q7AVMMUUZDSkS2a8Y=
+github.com/anoduck/mod-countup v0.1.0 h1:/esJZFBB/Sk7F9Zmd54PcXb9sqxxPidSQHjYF9/EVtM=
+github.com/anoduck/mod-countup v0.1.0/go.mod h1:j4DhQAAE6qmED5KD3o43cCHYD0Q7AVMMUUZDSkS2a8Y=
 github.com/gethinode/mod-template v0.0.0-20240304031439-297f26e96855 h1:79n9BJStYGBmvg2wXq0CdpDH1+jYlvLa68iaiAsHw0M=
 github.com/gethinode/mod-template v0.0.0-20240304031439-297f26e96855/go.mod h1:6ofWqxiQMhTnI8U6mT3FrEUN1UZ0vcUcZyXVIny2CZs=
 github.com/gethinode/mod-template v0.0.0-20240304050912-e05887822540 h1:wdzsVwBiQyKkUNxDE06cn66CMzL04I86XP0cMNKM4+4=

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anoduck/mod-countup",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "A Hugo module for Hinode to add a countup timer shortcode",
   "keywords": [
     "hugo",


### PR DESCRIPTION
Reduced margins to 0, in order for timer to fit inside of Hinode's container.